### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A starter template for building MCP (Model Context Protocol) servers. This boilerplate provides a clean foundation for creating your own MCP server that can integrate with Claude, Cursor, or other MCP-compatible AI assistants.
 
+<a href="https://glama.ai/mcp/servers/@CaptainCrouton89/mcp-reasoning">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@CaptainCrouton89/mcp-reasoning/badge" alt="Server Boilerplate MCP server" />
+</a>
+
 ## Purpose
 
 This boilerplate helps you quickly start building:


### PR DESCRIPTION
This PR adds a badge for the [MCP Server Boilerplate](https://glama.ai/mcp/servers/@CaptainCrouton89/mcp-reasoning) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@CaptainCrouton89/mcp-reasoning">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@CaptainCrouton89/mcp-reasoning/badge" alt="Server Boilerplate MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.